### PR TITLE
Fixed Score redrawing issue

### DIFF
--- a/Faky Bird 08/main.lua
+++ b/Faky Bird 08/main.lua
@@ -182,6 +182,7 @@ local function onUpdate (event)
 		if (myObTable[i].pBot.x <= -20) then
 			myObTable[i].pBot.x = 460--myObTable[#myObTable].pBot.x + 120
 			myScore = myScore + 1
+			myScoreDisplay.text = ""
 			myScoreDisplay.text = "Score: "..myScore
 		end
 	end

--- a/Faky Bird Final/playGame.lua
+++ b/Faky Bird Final/playGame.lua
@@ -110,6 +110,7 @@ function scene:createScene( event )
 		group:insert (promptReplay)
 		local function replay(event)
 			if (event.phase == "began") then
+				myScoreDisplay.text = ""
 				storyboard.gotoScene ("mainMenu", {effect = "fade", time = 1000})
 			end
 		end

--- a/Faky Bird Final/playGame.lua
+++ b/Faky Bird Final/playGame.lua
@@ -73,6 +73,7 @@ function scene:createScene( event )
 			if (myObstacles[i].pBot.x <= -20) then
 				myObstacles[i].pBot.x = 460--myObTable[#myObTable].pBot.x + 120
 				myScore = myScore + 1
+				myScoreDisplay.text = ""
 				myScoreDisplay.text = "Score: "..myScore
 			end
 		end


### PR DESCRIPTION
I experienced an issue whn redrawing scores, both in emulator & amdroid device
When the new "Score: ..." text was placed, the old one was still there, so it overlapped
